### PR TITLE
Fix issues with shp2geobuf

### DIFF
--- a/bin/shp2geobuf
+++ b/bin/shp2geobuf
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max-old-space-size=8192
 
 var encode = require('../encode'),
     Pbf = require('pbf'),
@@ -45,4 +45,5 @@ else
     var geobuf = encode(geojson, new Pbf());
     var output_buffer = Buffer.allocUnsafe ? Buffer.from(geobuf) : new Buffer(geobuf);
     process.stdout.write(output_buffer);
+    });
 }


### PR DESCRIPTION
#Description
Fix issues with shp2geobuf

#Fixes
- add missing brackets at end of file
- add --max-old-space-size parameter to header to avoid OOM issues with large shapefiles